### PR TITLE
Add relative-path macros

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,9 +11,11 @@
   ],
   "words": [
     "adoc",
+    "cfgs",
     "clippy",
     "doctest",
     "repr",
+    "rustc",
     "rustlang",
     "rustup"
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+  "rust-analyzer.cargo.cfgs": [
+    "debug_assertions",
+    "miri",
+    "rust-analyzer"
+  ],
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.checkOnSave": true,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,9 @@ quote = "1.0.42"
 
 [lints.clippy]
 test_attr_in_doctest = "allow"
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+    "cfg(rust_analyzer)",
+    "cfg(span_locations)",
+] }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can demonstrate just the code you want in markdown while maintaining the ben
 ## Examples
 
 The `include_markdown!()` macro resolves a file path relative to the directory containing the crate `Cargo.toml` manifest file.
+When compiled with Rust version 1.88.0 or newer, you can use macros like `include_relative_markdown!()` to resolve file paths relative to the source file directory that invoked the macro.
 
 Consider a crate `README.md` with the following content:
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,87 @@
 // Copyright 2025 Heath Stewart.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+use std::{cmp::Ordering, env, process::Command, str::FromStr};
+
+const MIN_SPAN_LOCATIONS_VER: Version = Version::new(1, 88, 0);
+
 fn main() {
     println!("cargo::rerun-if-changed=README.md");
+    if matches!(rustc_version(), Ok(version) if version >= MIN_SPAN_LOCATIONS_VER) {
+        println!("cargo::rustc-cfg=span_locations");
+    }
+}
+
+fn rustc_version() -> Result<Version, Box<dyn std::error::Error>> {
+    let output = Command::new(env::var("RUSTC")?).arg("--version").output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let mut words = stdout.split_whitespace();
+    words.next().ok_or("expected `rustc`")?;
+    let version: Version = words.next().ok_or("expected version")?.parse()?;
+    Ok(version)
+}
+
+#[derive(Debug, Default, Eq)]
+struct Version {
+    major: u16,
+    minor: u16,
+    patch: u16,
+}
+
+impl Version {
+    const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl FromStr for Version {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // cspell:ignore splitn
+        let mut values = s.splitn(3, ".").map(str::parse::<u16>);
+        Ok(Self {
+            major: values
+                .next()
+                .ok_or("no major version")?
+                .map_err(|err| err.to_string())?,
+            minor: values
+                .next()
+                .ok_or("no minor version")?
+                .map_err(|err| err.to_string())?,
+            patch: values
+                .next()
+                .ok_or("no patch version")?
+                .map_err(|err| err.to_string())?,
+        })
+    }
+}
+
+impl PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        self.major == other.major && self.minor == other.minor && self.patch == other.patch
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let cmp = self.major.cmp(&other.major);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = self.minor.cmp(&other.minor);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        self.patch.cmp(&other.patch)
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }

--- a/src/asciidoc.rs
+++ b/src/asciidoc.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 use proc_macro2::TokenStream;
-use std::{fs, io};
+use std::{fs, io, path::PathBuf};
 
-pub fn include_asciidoc(item: TokenStream) -> syn::Result<TokenStream> {
-    super::include_file(item, collect::<fs::File>)
+pub fn include_asciidoc(item: TokenStream, root: Option<PathBuf>) -> syn::Result<TokenStream> {
+    super::include_file(item, root, collect::<fs::File>)
 }
 
 fn collect<R: io::Read>(name: &str, iter: io::Lines<io::BufReader<R>>) -> io::Result<Vec<String>> {

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 use proc_macro2::TokenStream;
-use std::{fs, io};
+use std::{fs, io, path::PathBuf};
 
-pub fn include_markdown(item: TokenStream) -> syn::Result<TokenStream> {
-    super::include_file(item, collect::<fs::File>)
+pub fn include_markdown(item: TokenStream, root: Option<PathBuf>) -> syn::Result<TokenStream> {
+    super::include_file(item, root, collect::<fs::File>)
 }
 
 fn collect<R: io::Read>(name: &str, iter: io::Lines<io::BufReader<R>>) -> io::Result<Vec<String>> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,7 @@ fn collect<R: io::Read>(
 #[test]
 fn parse_two_args() {
     let tokens = quote! { "README.md", "example" };
-    include_file(tokens.clone(), collect).expect("expected TokenStream");
+    include_file(tokens.clone(), None, collect).expect("expected TokenStream");
 
     let args: MarkdownArgs = parse2(tokens).expect("expected parse2");
     assert_eq!(args.path.value(), "README.md");
@@ -27,40 +27,40 @@ fn parse_two_args() {
 #[test]
 fn parse_no_args_err() {
     let tokens = TokenStream::new();
-    include_file(tokens, collect).expect_err("expected parse error");
+    include_file(tokens, None, collect).expect_err("expected parse error");
 }
 
 #[test]
 fn parse_one_args_err() {
     let tokens = quote! { "README.md" };
-    include_file(tokens, collect).expect_err("expected parse error");
+    include_file(tokens, None, collect).expect_err("expected parse error");
 }
 
 #[test]
 fn parse_three_args_err() {
     let tokens = quote! { "README.md", "example", "other" };
-    include_file(tokens, collect).expect_err("expected parse error");
+    include_file(tokens, None, collect).expect_err("expected parse error");
 }
 
 #[test]
 fn parse_no_sep_err() {
     let tokens = quote! { "README.md" "example" };
-    include_file(tokens, collect).expect_err("expected parse error");
+    include_file(tokens, None, collect).expect_err("expected parse error");
 }
 
 #[test]
 fn parse_semicolon_sep_err() {
     let tokens = quote! { "README.md"; "example" };
-    include_file(tokens, collect).expect_err("expected parse error");
+    include_file(tokens, None, collect).expect_err("expected parse error");
 }
 
 #[test]
 fn open_file() {
-    let file = open("README.md").expect("expected README.md");
+    let file = open(None, "README.md").expect("expected README.md");
     assert!(matches!(file.metadata(), Ok(meta) if meta.is_file()));
 }
 
 #[test]
 fn open_err() {
-    assert!(matches!(open("missing.txt"), Err(err) if err.kind() == io::ErrorKind::NotFound));
+    assert!(matches!(open(None, "missing.txt"), Err(err) if err.kind() == io::ErrorKind::NotFound));
 }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -10,9 +10,35 @@ fn test_asciidoc() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[cfg_attr(not(span_locations), ignore)]
+fn test_relative_asciidoc() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(all(span_locations, not(rust_analyzer)))]
+    {
+        // rust-analyzer does not implement Span::local_file(): https://github.com/rust-lang/rust-analyzer/issues/15950
+        include_file::include_relative_asciidoc!("README.adoc", "example");
+        Ok(())
+    }
+    #[cfg(any(not(span_locations), rust_analyzer))]
+    panic!("not supported")
+}
+
+#[test]
 fn test_markdown() -> Result<(), Box<dyn std::error::Error>> {
     include_markdown!("README.md", "example");
     Ok(())
+}
+
+#[test]
+#[cfg_attr(not(span_locations), ignore)]
+fn test_relative_markdown() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(all(span_locations, not(rust_analyzer)))]
+    {
+        // rust-analyzer does not implement Span::local_file(): https://github.com/rust-lang/rust-analyzer/issues/15950
+        include_file::include_relative_markdown!("../README.md", "example");
+        Ok(())
+    }
+    #[cfg(any(not(span_locations), rust_analyzer))]
+    panic!("not supported")
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Requires Rust version 1.88.0 or newer.
