### PR TITLE
Update skill docs and package config

### DIFF
--- a/.github/skills/check-spelling/SKILL.md
+++ b/.github/skills/check-spelling/SKILL.md
@@ -1,43 +1,25 @@
 ---
 name: check-spelling
-description: Check and fix spelling in project source files using cSpell
+description: Run before marking any request complete if docs, comments, or text content changed. Use when checking or fixing spelling errors.
 ---
 
-# Spell checking
+# Check Spelling
 
-## Installation and usage
+Install: `npm i`
 
-Run `npm install` from the repository root to install `cspell` from `devDependencies` in the root `package.json`. Then run `npx cspell <command>` to use the locally installed version.
+Check changed files:
 
-## Configuration
-
-The cSpell configuration is in `.cspell.json` at the repository root. When running any cspell command, pass `--config .cspell.json`.
-
-The configuration has the following structure:
-
-- `words`: array of accepted words applied repo-wide.
-- `overrides`: array of per-glob overrides, each with a `filename` glob and its own `words` array.
-- `ignorePaths`: array of paths excluded from spell checking.
-
-## Check spelling
-
-Run `npx cspell lint --config .cspell.json .` to check spelling across the repository.
-
-## Fix spelling
-
-Show a summary of the misspelling to the user. Prompt the user for which words should be replaced with another word.
-
-Add remaining words to `.cspell.json`:
-
-- If a word appears only in files matching an existing override `filename` glob, add it to that override's `words` array.
-- Otherwise, add it to the top-level `words` array.
-
-Seldom used words can be ignored within the file they appear by adding an inline comment:
-
-```rust
-// cspell:ignore <word>
+```bash
+git diff --name-only --diff-filter=d HEAD | npx cspell lint --config .cspell.json --file-list stdin
 ```
 
-## Testing
+Auto-fix obvious misspellings:
 
-Run the same command again used to check spelling. All misspellings should be fixed.
+```bash
+git diff --name-only --diff-filter=d HEAD | npx cspell lint --config .cspell.json --fix --file-list stdin
+```
+
+- Unknown words: ask whether to correct the spelling or add to the nearest config
+- **Finding the config**: walk up ancestor directories looking for `.cspell.json`, then `cspell.json` in each directory; if you reach the git root without finding one, also check `.vscode/cspell.json`
+- **Adding words**: edit the config file directly — add to the `words` array (general terms) or `dictionaryDefinitions[name="crates"].words` (Rust crates)
+- Verify after adding words: rerun the check command

--- a/.github/skills/lint-markdown/SKILL.md
+++ b/.github/skills/lint-markdown/SKILL.md
@@ -1,38 +1,19 @@
 ---
 name: lint-markdown
-description: Check and fix formatting and other issues in markdown files using markdownlint-cli2
+description: Run automatically whenever any markdown file is modified. Use when linting or fixing markdown formatting.
 ---
 
-# Markdown linting
+# Lint Markdown
 
-Check markdown files for common mistakes.
+Install: `npm i`
 
-## Installation and usage
-
-Run `npm install` from the repository root to install `markdownlint-cli2` from `devDependencies` in the root `package.json`. Then run `npx markdownlint-cli2 <command>` to use the locally installed version.
-
-## Configuration
-
-The markdownlint-cli2 configuration is in `.markdownlint-cli2.yaml` at the repository root.
-
-The configuration has the following structure:
-
-- `globs`: file patterns to lint (currently `**/*.md`), so no command-line arguments are needed.
-- `ignores`: paths excluded from linting.
-- `config`: markdownlint rule overrides (e.g., `first-line-h1`, `line-length`, `ol-prefix`).
-
-## Check Markdown
-
-Run `npx markdownlint-cli2` to lint Markdown files according to the configuration.
-
-## Fix issues
-
-Run with the `--fix` flag to automatically fix supported issues:
+Fix changed markdown files:
 
 ```bash
-npx markdownlint-cli2 --fix
+npx markdownlint-cli2 --no-globs --fix $(git diff --name-only --diff-filter=d HEAD -- '*.md' '*.markdown')
 ```
 
-## Testing
-
-Run the same lint command again to verify all issues are fixed. There should be no errors reported.
+- `--no-globs` prevents falling back to config globs when no files changed
+- Auto-fix handles most issues
+- Unfixable issues: show the output to the user and ask what to do
+- Config: `.markdownlint-cli2.yaml` · [Rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "devDependencies": {
         "cspell": "^9.7.0",
         "markdownlint-cli2": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
@@ -142,7 +145,6 @@
       "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -224,8 +226,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
       "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -365,16 +366,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
       "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -572,8 +571,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -1600,7 +1598,6 @@
       "integrity": "sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "16.1.0",
         "js-yaml": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "devDependencies": {
     "cspell": "^9.7.0",
     "markdownlint-cli2": "^0.21.0"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
Streamline check-spelling and lint-markdown SKILL.md files with concise,
actionable instructions. Add engines and private fields to package.json.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
